### PR TITLE
Configure Karma to use ChromeHeadless

### DIFF
--- a/web/karma.conf.js
+++ b/web/karma.conf.js
@@ -25,7 +25,7 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['ChromeHeadless'],
     singleRun: false,
     restartOnFileChange: true
   });


### PR DESCRIPTION
Chrome doesn't seem to work on the remote setup we are using. The errors
I'm getting when running `npm run test` look like this:

    17 07 2020 23:13:06.698:WARN [karma]: No captured browser, open http://localhost:9876/
    17 07 2020 23:13:06.705:INFO [karma-server]: Karma v5.0.9 server started at http://0.0.0.0:9876/
    17 07 2020 23:13:06.705:INFO [launcher]: Launching browsers Chrome with concurrency unlimited
    17 07 2020 23:13:06.709:INFO [launcher]: Starting browser Chrome
    17 07 2020 23:13:07.595:ERROR [launcher]: Cannot start Chrome
        [990616:990616:0717/231307.508014:ERROR:browser_main_loop.cc(1469)] Unable to open X display.
    [0717/231307.533182:ERROR:nacl_helper_linux.cc(308)] NaCl helper process running without a sandbox!
    Most likely you need to configure your SUID sandbox correctly
    
    17 07 2020 23:13:07.595:ERROR [launcher]: Chrome stdout:
    17 07 2020 23:13:07.595:ERROR [launcher]: Chrome stderr: [990616:990616:0717/231307.508014:ERROR:browser_main_loop.cc(1469)] Unable to open X display.
    [0717/231307.533182:ERROR:nacl_helper_linux.cc(308)] NaCl helper process running without a sandbox!
    Most likely you need to configure your SUID sandbox correctly

Switching to ChromeHeadless seems to fix the issue.
