### PR TITLE
Update the AppRoutingModule to route to our pages

### DIFF
--- a/web/src/app/app-routing.module.ts
+++ b/web/src/app/app-routing.module.ts
@@ -1,7 +1,38 @@
 import { NgModule } from '@angular/core';
-import { Routes, RouterModule } from '@angular/router';
+import { Routes, RouterModule, UrlSegment, UrlMatchResult } from '@angular/router';
 
-const routes: Routes = [];
+import { AllPushesComponent } from './pages/all-pushes/all-pushes.component';
+import { MyPushesComponent } from './pages/my-pushes/my-pushes.component';
+import { OnePushComponent } from './pages/one-push/one-push.component';
+
+/**
+ * Matcher for the URLs for individual pushes.
+ *
+ * EXample: /test/razvanm/helloworld/@20180503-163004.520847
+ */
+export function onePushMatcher(segments: UrlSegment[]): UrlMatchResult {
+  const noMatch = {consumed: []};
+  if (!segments[segments.length - 1].path.startsWith('@')) {
+    return noMatch;
+  }
+  return {consumed: segments};
+}
+
+const routes: Routes = [
+  {
+    path: '',
+    component: MyPushesComponent,
+    pathMatch: 'full',
+  },
+  {
+    component: OnePushComponent,
+    matcher: onePushMatcher,
+  },
+  {
+    path: '**',
+    component: AllPushesComponent,
+  },
+];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],

--- a/web/src/app/app-routing.module.ts
+++ b/web/src/app/app-routing.module.ts
@@ -8,7 +8,7 @@ import { OnePushComponent } from './pages/one-push/one-push.component';
 /**
  * Matcher for the URLs for individual pushes.
  *
- * EXample: /test/razvanm/helloworld/@20180503-163004.520847
+ * Example: /test/razvanm/helloworld/@20180503-163004.520847
  */
 export function onePushMatcher(segments: UrlSegment[]): UrlMatchResult {
   const noMatch = {consumed: []};

--- a/web/src/app/pages/all-pushes/all-pushes.component.html
+++ b/web/src/app/pages/all-pushes/all-pushes.component.html
@@ -1,1 +1,3 @@
 <p>all-pushes works!</p>
+
+<a routerLink='@timestamp'>timestamp</a>

--- a/web/src/app/pages/my-pushes/my-pushes.component.html
+++ b/web/src/app/pages/my-pushes/my-pushes.component.html
@@ -1,1 +1,3 @@
 <p>my-pushes works!</p>
+
+<a routerLink='push-def'>push-def</a>


### PR DESCRIPTION
The AppRoutingModule is changed to route our pages in the following way:

  - use the MyPushesComponent for the root page
  - use the OnePushComponent for the URLs that contains '/@'
  - use the AllPushesComponent for all the other pages.

This PR also populates the HTML for the components for the pages with
some temporary links to deponstrate the routing.