### PR TITLE
Configure Protractor to use Chrome in headless mode

### DIFF
--- a/web/e2e/protractor.conf.js
+++ b/web/e2e/protractor.conf.js
@@ -13,7 +13,10 @@ exports.config = {
     './src/**/*.e2e-spec.ts'
   ],
   capabilities: {
-    browserName: 'chrome'
+    browserName: 'chrome',
+    chromeOptions: {
+      args: ["--headless"]
+    }
   },
   directConnect: true,
   baseUrl: 'http://localhost:4200/',


### PR DESCRIPTION
This gets the `npm run e2e` to work on the remote setup we are using.