### PR TITLE
Pin the ChromeDriver version for Webdriver Manager

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,8 @@
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e --webdriverUpdate=false",
+    "postinstall": "node_modules/.bin/webdriver-manager update --gecko false --standalone false --versions.chrome=84.0.4147.89"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Letting the `ng e2e` update the ChromeDriver version for Webdriver Manager can
cause issues because it might not match the version on we use on our remote
development environment. This PR is configuring the Webdriver Manager to use
the ChromeDriver version  that matches the Chrome version we currently have on
our remote environment.

Sample error:

    [21:43:23] E/launcher - session not created: This version of ChromeDriver only supports Chrome version 85
      (Driver info: chromedriver=85.0.4183.38 (9047dbc2c693f044042bbec5c91401c708c7c26a-refs/branch-heads/4183@{#779}),platform=Linux 4.15.0-1077-aws x86_64)