### PR TITLE
Move the `npm ci` to a separate step for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,22 +11,21 @@ jobs:
       - checkout
 
       - run:
+          name: node_modules
+          working_directory: web
+          command: npm ci
+
+      - run:
           name: lint
           working_directory: web
-          command: |
-            npm ci
-            npm run lint
+          command: npm run lint
 
       - run:
           name: test
           working_directory: web
-          command: |
-            npm ci
-            npm run test -- --watch=false
+          command: npm run test -- --watch=false
 
       - run:
           name: e2e
           working_directory: web
-          command: |
-            npm ci
-            npm run e2e
+          command: npm run e2e


### PR DESCRIPTION
In CircleC all the steps run in a single session so it's sufficient to
run the `npm ci` once at the beginning.