### PR TITLE
Fix the App Engine version for pushes to the main branch

### DIFF
--- a/.github/workflows/appengine-deploy.yml
+++ b/.github/workflows/appengine-deploy.yml
@@ -18,13 +18,13 @@ jobs:
       - name: Check out
         uses: actions/checkout@v2
 
-      - name: Set App Engine version for the push to main
+      - name: Set env variables for the push to main
         if: github.ref == 'refs/heads/main'
         run: |
           echo "::set-env name=APPENGINE_VERSION_PREFIX::main"
           echo "::set-env name=SHA_SHORT::$(git rev-parse --short=7 ${{ github.sha }})"
 
-      - name: Set App Engine version for the pull request
+      - name: Set env variables for the pull request
         if: github.ref != 'refs/heads/main'
         run: |
           echo "::set-env name=APPENGINE_VERSION_PREFIX::pr${{ github.event.pull_request.number }}"

--- a/.github/workflows/appengine-deploy.yml
+++ b/.github/workflows/appengine-deploy.yml
@@ -18,16 +18,17 @@ jobs:
       - name: Check out
         uses: actions/checkout@v2
 
-      - name: Set SHA_SHORT
-        run: echo "::set-env name=SHA_SHORT::$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})"
-
-      - name: Set APPENGINE_VERSION_PREFIX to main
+      - name: Set App Engine version for the push to main
         if: github.ref == 'refs/heads/main'
-        run: echo '::set-env name=APPENGINE_VERSION_PREFIX::main'
+        run: |
+          echo "::set-env name=APPENGINE_VERSION_PREFIX::main"
+          echo "::set-env name=SHA_SHORT::$(git rev-parse --short=7 ${{ github.sha }})"
 
-      - name: Set APPENGINE_VERSION_PREFIX to current PR
+      - name: Set App Engine version for the pull request
         if: github.ref != 'refs/heads/main'
-        run: echo '::set-env name=APPENGINE_VERSION_PREFIX::pr${{ github.event.pull_request.number }}'
+        run: |
+          echo "::set-env name=APPENGINE_VERSION_PREFIX::pr${{ github.event.pull_request.number }}"
+          echo "::set-env name=SHA_SHORT::$(git rev-parse --short=7 ${{ github.event.pull_request.head.sha }})"
 
       - name: Build
         working-directory: web


### PR DESCRIPTION
This PR fixes the missing commit hash from the App Engine versions produced by
the GitHub Actions workflow triggered for pushes to the main branch.

The problem was that `github.event.pull_request.head.sha` only works for pull
requests. The solution for pushes to the main branch is `github.sha`.