### PR TITLE
Enable strict mode in Angular

### DIFF
--- a/web/angular.json
+++ b/web/angular.json
@@ -8,6 +8,9 @@
       "schematics": {
         "@schematics/angular:component": {
           "style": "scss"
+        },
+        "@schematics/angular:application": {
+          "strict": true
         }
       },
       "root": "",
@@ -51,13 +54,13 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "2mb",
-                  "maximumError": "5mb"
+                  "maximumWarning": "500kb",
+                  "maximumError": "1mb"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "6kb",
-                  "maximumError": "10kb"
+                  "maximumWarning": "2kb",
+                  "maximumError": "4kb"
                 }
               ]
             }

--- a/web/src/app/package.json
+++ b/web/src/app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "web",
+  "private": true,
+  "description_1": "This is a special package.json file that is not used by package managers.",
+  "description_2": "It is used to tell the tools and bundlers whether the code under this directory is free of code with non-local side-effect. Any code that does have non-local side-effects can't be well optimized (tree-shaken) and will result in unnecessary increased payload size.",
+  "description_3": "It should be safe to set this option to 'false' for new applications, but existing code bases could be broken when built with the production config if the application code does contain non-local side-effects that the application depends on.",
+  "description_4": "To learn more about this file see: https://angular.io/config/app-package-json.",
+  "sideEffects": false
+}

--- a/web/tsconfig.base.json
+++ b/web/tsconfig.base.json
@@ -4,6 +4,10 @@
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
     "declaration": false,
     "downlevelIteration": true,
@@ -16,5 +20,9 @@
       "es2018",
       "dom"
     ]
+  },
+  "angularCompilerOptions": {
+    "strictInjectionParameters": true,
+    "strictTemplates": true
   }
 }

--- a/web/tslint.json
+++ b/web/tslint.json
@@ -55,6 +55,7 @@
         ]
       }
     ],
+    "no-any": true,
     "no-console": [
       true,
       "debug",


### PR DESCRIPTION
This PR enables strict mode in Angular by updating several configuration files
and adding an additional `package.json` file to `web/src/app/` directory.

According to Angular website, Angular strict mode does the following:

- Enables strict mode in TypeScript, as well as other strictness flags
  recommended by the TypeScript team. Specifically,
  `forceConsistentCasingInFileNames`, `noImplicitReturns`,
  `noFallthroughCasesInSwitch`.
- Turns on strict Angular compiler flags `strictTemplates` and
  `strictInjectionParameters`.
- Reduces bundle size budgets by ~75%.
- Turns on `no-any` tslint rule to prevent declarations of type `any`.
- Marks the application as side-effect free to enable more advanced
  tree-shaking.

The changes in this PR were obtained by creating a new Angular application
project in strict mode and then comparing the configuration files with the
existing ones.