### PR TITLE
Fix mistake of getting most recent commit hash to main

### DIFF
--- a/.github/workflows/appengine-deploy.yml
+++ b/.github/workflows/appengine-deploy.yml
@@ -39,7 +39,7 @@ jobs:
       
       - name: Set golden hash
         run: |
-          echo "::set-env name=GOLDEN_HASH::$(git rev-parse origin/main)"
+          echo "::set-env name=GOLDEN_HASH::$(git ls-remote git://github.com/googleinterns/step189-2020.git refs/heads/main | cut -f 1)"
           
       - name: Build
         working-directory: web

--- a/.github/workflows/appengine-deploy.yml
+++ b/.github/workflows/appengine-deploy.yml
@@ -39,7 +39,7 @@ jobs:
       
       - name: Set golden hash
         run: |
-          echo "::set-env name=GOLDEN_HASH::$(git rev parse origin/main)"
+          echo "::set-env name=GOLDEN_HASH::$(git rev-parse origin/main)"
           
       - name: Build
         working-directory: web


### PR DESCRIPTION
There was a typo in the previous PR with `git rev parse` getting the most recent
commit to main. After changing it to `git rev-parse`, the following error occurs:

    ambiguous argument 'origin/main': unknown revision or path not in the working tree.

I am instead using `git ls-remote` to list and get the most recent commit to main.