### PR TITLE
Skip the postinstall script in production mode

### DIFF
--- a/web/app.yaml
+++ b/web/app.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs10
+runtime: nodejs12
  
 handlers:
 - url: /

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e --webdriverUpdate=false",
-    "postinstall": "node_modules/.bin/webdriver-manager update --gecko false --standalone false --versions.chrome=84.0.4147.89",
+    "postinstall": "./postinstall.sh",
     "genproto": "pbjs -w es6 -t static-module -o src/proto/step189_2020.js src/proto/step189_2020.proto && pbts -o src/proto/step189_2020.d.ts src/proto/step189_2020.js",
     "happo": "happo",
     "happo-ci-github-actions": "happo-ci-github-actions"
@@ -23,8 +23,8 @@
     "@angular/platform-browser": "~10.0.4",
     "@angular/platform-browser-dynamic": "~10.0.4",
     "@angular/router": "~10.0.4",
-    "protobufjs": "~6.10.1",
     "babel-core": "^7.0.0-bridge.0",
+    "protobufjs": "~6.10.1",
     "rxjs": "~6.5.5",
     "tslib": "^2.0.0",
     "zone.js": "~0.10.3"

--- a/web/postinstall.sh
+++ b/web/postinstall.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if [ "${NODE_ENV}" != 'production' ]
+then
+    # We pin the ChromeDriver version to the version we currently have on our
+    # remote enviroment because letting the `ng e2e` update the driver
+    # automatically can cause problems (see #10 for more details).
+    node_modules/.bin/webdriver-manager update \
+        --gecko false \
+        --standalone false \
+        --versions.chrome=84.0.4147.89
+fi


### PR DESCRIPTION
The pinning we do in the postinstall script is not necessary in
production mode and is causing problems in App Engine because the Cloud
Build is running that step.

This PR also switches the App Engine runtime to nodejs12 which showed
this issue consistently. Based on the error logs from Cloud Build I
suspect the update that is going on for the nodejs10 runtime will also
run the postinstall script.