### PR TITLE
Add Happo checks for all-pushes and one-push pages

### DIFF
--- a/web/.happo.js
+++ b/web/.happo.js
@@ -9,10 +9,10 @@ module.exports = {
     { url: process.env.URL, title: 'my-pushes' },
     { url: process.env.URL + "/28a1555e453f", title: 'all-pushes 11k' },
     { url: process.env.URL + "/28a1555e453f/@20200805-211425.620604", title: 'built unchanged one-push 11k' },
-    //{ url: process.env.URL/28a1555e453f/@20200724-212811.116442, title: 'completed one-push 11k' },
-    //{ url: process.env.URL/7f4535707267, title: 'all-pushes 83' },
-    //{ url: process.env.URL/7f4535707267/@20200413-170000.042638, title: 'completed one push 83' },
-    //{ url: process.env.URL/7f4535707267/@20200316-170000.080599, title: 'reverted one push 83' },
+    { url: process.env.URL + "/28a1555e453f/@20200724-212811.116442", title: 'completed one-push 11k' },
+    { url: process.env.URL + "/7f4535707267", title: 'all-pushes 83' },
+    { url: process.env.URL + "/7f4535707267/@20200413-170000.042638", title: 'completed one push 83' },
+    { url: process.env.URL + "/7f4535707267/@20200316-170000.080599", title: 'reverted one push 83' },
   ],
 
   targets: {


### PR DESCRIPTION
This PR adds screenshot testing to the all-pushes and one-push pages. Originally, 
it was only testing the home page. Now, it includes testing of the all-pushes pages 
with 11k and 83 pushes. It also tests the one-push page with a completed push 
and a built unchanged push for the push def with 11k pushes as well as a 
reverted and completed push for the push def with 83 pushes. Currently, there 
is an issue with the testing of the all-pushes page because it takes a screenshot 
before the table is loaded in. This will be fixed in a subsequent PR.

This PR also deletes an unnecessary TypeScript plugin and removes testing on 
a Firefox browser.