### PR TITLE
Add user interaction to CDF chart

### DIFF
--- a/web/src/app/components/cdf/cdf.component.ts
+++ b/web/src/app/components/cdf/cdf.component.ts
@@ -3,7 +3,7 @@ import * as d3 from 'd3';
 
 import {step189_2020} from '../../../proto/step189_2020';
 
-import {addCurrentPushLine, generateQuantiles, generateYPosition, populateData} from './cdf.utils';
+import {addCurrentPushLine, getProbabilityForDuration, generateQuantiles, generateYPosition, populateData} from './cdf.utils';
 import {COMPLETED_BLUE, d3SVG, Item, STROKE_COLOR} from './cdf.utils';
 
 @Component({
@@ -92,7 +92,8 @@ export class CDFComponent implements AfterViewInit {
     const extendedData = Array.from(this.data);
     extendedData.push(
         {duration: xScale.ticks()[xScale.ticks().length - 1], probability: 1});
-
+    
+    const maxExtendedDuration = extendedData[extendedData.length - 1].duration;
     this.svg = (d3.select(element).append('svg') as d3SVG)
                    .attr('width', elementWidth)
                    .attr('height', elementHeight);
@@ -245,5 +246,220 @@ export class CDFComponent implements AfterViewInit {
 
     addCurrentPushLine(
         this.currentPush, currentPushLine, this.data, height, xScale, yScale);
+
+    // Mouse click
+    let startValue = minDuration + 1;
+
+    const clipRect = cdfChart
+      .append('clipPath')
+      .attr('id', 'area-clip')
+      .append('rect')
+      .attr('class', 'area-clip-rect')
+      .attr('x', 0)
+      .attr('y', 0)
+      .attr('width', xScale(startValue))
+      .attr('height', height);
+
+    cdfChart
+      .datum(extendedData)
+      .append('path')
+      .attr('class', 'cdf-curve')
+      .attr('d', d3.area<Item>()
+        .x(d => xScale(d.duration))
+        .y1(d => yScale(d.probability))
+        .y0(yScale(0))
+        .curve(d3.curveStepAfter)
+      )
+      .attr('fill-opacity', '0.6')
+      .attr('fill', 'white')
+      .attr('clip-path', 'url(#area-clip)');
+
+    const lineY = cdfChart
+      .append('line')
+      .attr('class', 'click-line-y')
+      .attr('x1', xScale(startValue))
+      .attr('x2', xScale(startValue))
+      .attr('y1', yScale(getProbabilityForDuration(this.data, startValue)))
+      .attr('y2', height)
+      .attr('stroke', 'black')
+      .attr('stroke-width', '1px')
+      .attr('opacity', 0);
+
+    const lineX = cdfChart
+      .append('line')
+      .attr('class', 'click-line-x')
+      .attr('x1', 0)
+      .attr('x2', xScale(startValue))
+      .attr('y1', yScale(getProbabilityForDuration(this.data, startValue)))
+      .attr('y2', yScale(getProbabilityForDuration(this.data, startValue)))
+      .attr('stroke', 'black')
+      .attr('stroke-width', '1px')
+      .attr('opacity', 0);
+
+    cdfChart
+      .append('text')
+      .attr('x', xScale(startValue) - 35)
+      .attr('y', yScale(getProbabilityForDuration(this.data, startValue) / 100) + 30)
+      .attr('class', 'click-line-y-text')
+      .attr('font-size', '10px')
+      .text(`${this.data.filter(c => c.duration <= startValue).length}/${this.data.length}`)
+      .attr('opacity', 0);
+
+    cdfChart
+      .append('text')
+      .attr('x', xScale(startValue) / 2)
+      .attr('y', yScale(getProbabilityForDuration(this.data, startValue) / 100) + 10)
+      .attr('class', 'click-line-x-text')
+      .attr('font-size', '10px')
+      .text(`${getProbabilityForDuration(this.data, startValue).toFixed(2)}%`)
+      .attr('opacity', 0);
+
+    cdfChart.on('click', (d: unknown, i: number): void => {
+      if (!d) { return; }
+      const coordinates = d3.mouse(d3.event.currentTarget);
+      const xValue = xScale.invert(coordinates[0]);
+      if (xValue > minDuration) {
+        startValue = xValue;
+        const yValue = getProbabilityForDuration(d as Item[], startValue);
+        d3.select(d3.event.currentTarget)
+          .select('.area-clip-rect')
+          .attr('width', xScale(startValue));
+        d3.select(d3.event.currentTarget)
+          .select('.click-line-y')
+          .attr('y1', yScale(yValue))
+          .attr('x1', xScale(startValue))
+          .attr('x2', xScale(startValue))
+          .attr('opacity', 1);
+        d3.select(d3.event.currentTarget)
+          .select('.click-line-x')
+          .attr('y1', yScale(yValue))
+          .attr('y2', yScale(yValue))
+          .attr('x2', xScale(startValue))
+          .attr('opacity', 1);
+        d3.select(d3.event.currentTarget)
+          .select('.click-line-y-text')
+          .attr('x', xScale(startValue) - 40)
+          .attr('y', yScale(yValue) + 20)
+          .text(`${this.data.filter(c => c.duration <= startValue).length}/${this.data.length}`)
+          .attr('opacity', 1);
+        d3.select(d3.event.currentTarget)
+          .select('.click-line-x-text')
+          .attr('x', xScale(startValue) / 2)
+          .attr('y', yScale(yValue) + 10)
+          .text(`${(getProbabilityForDuration(this.data, startValue) * 100).toFixed(1)}%`)
+          .attr('opacity', 1);
+      }
+    });
+
+    // hover
+    const highlightColor = '#b9edc4';
+    const strokeColor = '#167364';
+    const circleColor = '#a0aade';
+    const labelsize = [40, 25];
+    const labelFontSize = labelsize[1] / 2;
+
+    cdfChart.append('rect')
+      .attr('class', 'x-label-bg')
+      .attr('x', 0)
+      .attr('y', height)
+      .attr('height', labelsize[1])
+      .attr('width', labelsize[0])
+      .attr('fill', highlightColor)
+      .attr('opacity', 0);
+
+    cdfChart.append('text')
+      .attr('text-anchor', 'middle')
+      .attr('class', 'y-label')
+      .attr('x', -labelsize[0] / 2)
+      .attr('y', 0)
+      .attr('opacity', 0)
+      .attr('fill', 'black')
+      .style('font-size', `${labelFontSize}px`);
+
+    cdfChart.append('line')
+      .attr('x1', 0)
+      .attr('x2', 0)
+      .attr('y1', height)
+      .attr('y2', 0)
+      .attr('class', 'v-ruler')
+      .attr('stroke', 'grey')
+      .attr('stroke-width', 2)
+      .attr('stroke-dasharray', '5,2')
+      .attr('opacity', 0);
+
+    cdfChart.append('line')
+      .attr('x1', 0)
+      .attr('x2', width)
+      .attr('y1', 0)
+      .attr('y2', 0)
+      .attr('class', 'h-ruler')
+      .attr('stroke', 'grey')
+      .attr('stroke-width', 2)
+      .attr('stroke-dasharray', '5,2')
+      .attr('opacity', 0);
+
+    cdfChart.append('circle')
+      .attr('class', 'marker')
+      .attr('cx', 0)
+      .attr('cy', 0)
+      .attr('r', 5)
+      .attr('stroke', strokeColor)
+      .attr('stroke-width', 2)
+      .attr('fill', circleColor)
+      .style('opacity', 0);
+
+    cdfChart.on('mouseover', (d: unknown, i: number): void => {
+      const mouseX = xScale.invert(d3.mouse(d3.event.currentTarget)[0]);
+      const vruler = d3.select('.v-ruler');
+      const hruler = d3.select('.h-ruler');
+      const marker = d3.select('.marker');
+      const xlabel = d3.select('.x-label');
+      const xlabelbg = d3.select('.x-label-bg');
+      const ylabel = d3.select('.y-label');
+      const ylabelbg = d3.select('.y-label-bg');
+      const checkX = (mouseX >= minDuration) && (mouseX <= maxExtendedDuration);
+
+      if (checkX) {
+        const xVal = d3.mouse(d3.event.currentTarget)[0];
+        const yVal = yScale(getProbabilityForDuration(d as Item[], xScale.invert(xVal)));
+
+        marker.attr('cx', xVal).attr('cy', yVal);
+        hruler.attr('y1', yVal).attr('y2', yVal);
+        vruler.attr('x1', xVal).attr('x2', xVal);
+
+        const xText = d3.format(',.1f')(xScale.invert(+marker.attr('cx')));
+        const yText = d3.format(',.1%')(yScale.invert(+marker.attr('cy')));
+        xlabel.attr('x', +marker.attr('cx')).text(xText);
+        xlabelbg.attr('x', +marker.attr('cx') - labelsize[0] / 2);
+        ylabel.attr('y', +marker.attr('cy') + labelsize[1] / 5).text(yText);
+        ylabelbg.attr('y', +marker.attr('cy') - labelsize[1] / 2);
+
+        marker.style('opacity', 1);
+        hruler.style('opacity', 1);
+        vruler.style('opacity', 1);
+        xlabel.style('opacity', 1);
+        xlabelbg.style('opacity', 1);
+        ylabel.style('opacity', 1);
+        ylabelbg.style('opacity', 1);
+      } else {
+        marker.style('opacity', 0);
+        hruler.style('opacity', 0);
+        vruler.style('opacity', 0);
+        xlabel.style('opacity', 0);
+        xlabelbg.style('opacity', 0);
+        ylabel.style('opacity', 0);
+        ylabelbg.style('opacity', 0);
+      }
+    });
+
+    cdfChart.on('mouseleave', (d: unknown, i: number): void => {
+      const vruler = d3.select('.v-ruler').style('opacity', 0);
+      const hruler = d3.select('.h-ruler').style('opacity', 0);
+      const marker = d3.select('.marker').style('opacity', 0);
+      const xlabel = d3.select('.x-label').style('opacity', 0);
+      const xlabelbg = d3.select('.x-label-bg').style('opacity', 0);
+      const ylabel = d3.select('.y-label').style('opacity', 0);
+      const ylabelbg = d3.select('.y-label-bg').style('opacity', 0);
+    });
   }
 }

--- a/web/src/app/components/cdf/cdf.component.ts
+++ b/web/src/app/components/cdf/cdf.component.ts
@@ -35,6 +35,7 @@ export class CDFComponent implements AfterViewInit {
    *     <g id='y-axis-right'></g>
    *     <path id='cdf-area'></path>
    *     <path id='cdf-stroke'></path>
+   *     <g id='dotplot-container'></g>
    *   </g>
    *   <g id='x-axis'></g>
    *   <text id='x-axis-label'></text>
@@ -42,7 +43,6 @@ export class CDFComponent implements AfterViewInit {
    *   <g id='percentile-lines'></g>
    *     <line class='percentile-line'></line>
    *     <text class='percentile-text'></text>
-   *   <g id='dotplot-container'></g>
    *   <g id='current-push-line'> (Only if the visited push is completed)
    *     <defs>
    *       <marker id='arrow'></marker>
@@ -210,11 +210,6 @@ export class CDFComponent implements AfterViewInit {
         .attr('font-size', '10px')
         .text((d: Item) => `${d.probability * 100}%`);
 
-    const dotplotContainer =
-        this.svg.append('g')
-            .attr('id', 'dotplot-container')
-            .attr('transform', `translate(${margin.left}, ${margin.top})`);
-
     let radius = 2.5;
     const xVals = this.data.map(d => d.duration);
     let yPosition = generateYPosition(radius * 2 + 0.1, xScale, xVals);
@@ -232,7 +227,8 @@ export class CDFComponent implements AfterViewInit {
     for (let i = 0; i < this.data.length; i++) {
       const cx = xScale(this.data[i].duration);
       const cy = height - yPosition[i] - radius;
-      dotplotContainer.append('circle')
+      cdfChart.append('circle')
+          .attr('class', 'dots')
           .attr('cx', cx)
           .attr('r', radius)
           .attr('cy', cy)
@@ -248,7 +244,7 @@ export class CDFComponent implements AfterViewInit {
         this.currentPush, currentPushLine, this.data, height, xScale, yScale);
 
     // Mouse click
-    let startValue = minDuration + 1;
+    let startValue = minDuration ;
 
     const clipRect = cdfChart
       .append('clipPath')
@@ -348,6 +344,11 @@ export class CDFComponent implements AfterViewInit {
           .attr('y', yScale(yValue) + 10)
           .text(`${(getProbabilityForDuration(this.data, startValue) * 100).toFixed(1)}%`)
           .attr('opacity', 1);
+        d3.select(d3.event.currentTarget)
+          .selectAll('.dots')
+          .data(this.data)
+          .enter()
+          .attr('fill', (d: Item) => (d.duration <= startValue ? 'grey' : 'black'));
       }
     });
 
@@ -362,6 +363,25 @@ export class CDFComponent implements AfterViewInit {
       .attr('class', 'x-label-bg')
       .attr('x', 0)
       .attr('y', height)
+      .attr('height', labelsize[1])
+      .attr('width', labelsize[0])
+      .attr('fill', highlightColor)
+      .attr('opacity', 0);
+
+    cdfChart.append('text')
+      .attr('text-anchor', 'middle')
+      .attr('class', 'x-label')
+      .attr('x', 0)
+      .attr('y', height + 5 + labelFontSize)
+      .attr('opacity', 0)
+      .style('font-size', `${labelFontSize}px`)
+      .style('font-weight', 'bold')
+      .attr('fill', 'black');
+
+    cdfChart.append('rect')
+      .attr('class', 'y-label-bg')
+      .attr('x', -labelsize[0])
+      .attr('y', 0)
       .attr('height', labelsize[1])
       .attr('width', labelsize[0])
       .attr('fill', highlightColor)

--- a/web/src/app/components/cdf/cdf.component.ts
+++ b/web/src/app/components/cdf/cdf.component.ts
@@ -3,7 +3,7 @@ import * as d3 from 'd3';
 
 import {step189_2020} from '../../../proto/step189_2020';
 
-import {addCurrentPushLine, getProbabilityForDuration, generateQuantiles, generateYPosition, populateData} from './cdf.utils';
+import {addCurrentPushLine, generateQuantiles, generateYPosition, getProbabilityForDuration, populateData} from './cdf.utils';
 import {COMPLETED_BLUE, d3SVG, Item, STROKE_COLOR} from './cdf.utils';
 
 @Component({
@@ -92,7 +92,7 @@ export class CDFComponent implements AfterViewInit {
     const extendedData = Array.from(this.data);
     extendedData.push(
         {duration: xScale.ticks()[xScale.ticks().length - 1], probability: 1});
-    
+
     const maxExtendedDuration = extendedData[extendedData.length - 1].duration;
     this.svg = (d3.select(element).append('svg') as d3SVG)
                    .attr('width', elementWidth)
@@ -244,111 +244,123 @@ export class CDFComponent implements AfterViewInit {
         this.currentPush, currentPushLine, this.data, height, xScale, yScale);
 
     // Mouse click
-    let startValue = minDuration ;
+    let startValue = minDuration;
 
-    const clipRect = cdfChart
-      .append('clipPath')
-      .attr('id', 'area-clip')
-      .append('rect')
-      .attr('class', 'area-clip-rect')
-      .attr('x', 0)
-      .attr('y', 0)
-      .attr('width', xScale(startValue))
-      .attr('height', height);
+    const clipRect = cdfChart.append('clipPath')
+                         .attr('id', 'area-clip')
+                         .append('rect')
+                         .attr('class', 'area-clip-rect')
+                         .attr('x', 0)
+                         .attr('y', 0)
+                         .attr('width', xScale(startValue))
+                         .attr('height', height);
 
-    cdfChart
-      .datum(extendedData)
-      .append('path')
-      .attr('class', 'cdf-curve')
-      .attr('d', d3.area<Item>()
-        .x(d => xScale(d.duration))
-        .y1(d => yScale(d.probability))
-        .y0(yScale(0))
-        .curve(d3.curveStepAfter)
-      )
-      .attr('fill-opacity', '0.6')
-      .attr('fill', 'white')
-      .attr('clip-path', 'url(#area-clip)');
+    cdfChart.datum(extendedData)
+        .append('path')
+        .attr('class', 'cdf-curve')
+        .attr(
+            'd',
+            d3.area<Item>()
+                .x(d => xScale(d.duration))
+                .y1(d => yScale(d.probability))
+                .y0(yScale(0))
+                .curve(d3.curveStepAfter))
+        .attr('fill-opacity', '0.6')
+        .attr('fill', 'white')
+        .attr('clip-path', 'url(#area-clip)');
 
-    const lineY = cdfChart
-      .append('line')
-      .attr('class', 'click-line-y')
-      .attr('x1', xScale(startValue))
-      .attr('x2', xScale(startValue))
-      .attr('y1', yScale(getProbabilityForDuration(this.data, startValue)))
-      .attr('y2', height)
-      .attr('stroke', 'black')
-      .attr('stroke-width', '1px')
-      .attr('opacity', 0);
+    const lineY =
+        cdfChart.append('line')
+            .attr('class', 'click-line-y')
+            .attr('x1', xScale(startValue))
+            .attr('x2', xScale(startValue))
+            .attr(
+                'y1', yScale(getProbabilityForDuration(this.data, startValue)))
+            .attr('y2', height)
+            .attr('stroke', 'black')
+            .attr('stroke-width', '1px')
+            .attr('opacity', 0);
 
-    const lineX = cdfChart
-      .append('line')
-      .attr('class', 'click-line-x')
-      .attr('x1', 0)
-      .attr('x2', xScale(startValue))
-      .attr('y1', yScale(getProbabilityForDuration(this.data, startValue)))
-      .attr('y2', yScale(getProbabilityForDuration(this.data, startValue)))
-      .attr('stroke', 'black')
-      .attr('stroke-width', '1px')
-      .attr('opacity', 0);
+    const lineX =
+        cdfChart.append('line')
+            .attr('class', 'click-line-x')
+            .attr('x1', 0)
+            .attr('x2', xScale(startValue))
+            .attr(
+                'y1', yScale(getProbabilityForDuration(this.data, startValue)))
+            .attr(
+                'y2', yScale(getProbabilityForDuration(this.data, startValue)))
+            .attr('stroke', 'black')
+            .attr('stroke-width', '1px')
+            .attr('opacity', 0);
 
-    cdfChart
-      .append('text')
-      .attr('x', xScale(startValue) - 35)
-      .attr('y', yScale(getProbabilityForDuration(this.data, startValue) / 100) + 30)
-      .attr('class', 'click-line-y-text')
-      .attr('font-size', '10px')
-      .text(`${this.data.filter(c => c.duration <= startValue).length}/${this.data.length}`)
-      .attr('opacity', 0);
+    cdfChart.append('text')
+        .attr('x', xScale(startValue) - 35)
+        .attr(
+            'y',
+            yScale(getProbabilityForDuration(this.data, startValue) / 100) + 30)
+        .attr('class', 'click-line-y-text')
+        .attr('font-size', '10px')
+        .text(`${this.data.filter(c => c.duration <= startValue).length}/${
+            this.data.length}`)
+        .attr('opacity', 0);
 
-    cdfChart
-      .append('text')
-      .attr('x', xScale(startValue) / 2)
-      .attr('y', yScale(getProbabilityForDuration(this.data, startValue) / 100) + 10)
-      .attr('class', 'click-line-x-text')
-      .attr('font-size', '10px')
-      .text(`${getProbabilityForDuration(this.data, startValue).toFixed(2)}%`)
-      .attr('opacity', 0);
+    cdfChart.append('text')
+        .attr('x', xScale(startValue) / 2)
+        .attr(
+            'y',
+            yScale(getProbabilityForDuration(this.data, startValue) / 100) + 10)
+        .attr('class', 'click-line-x-text')
+        .attr('font-size', '10px')
+        .text(`${getProbabilityForDuration(this.data, startValue).toFixed(2)}%`)
+        .attr('opacity', 0);
 
     cdfChart.on('click', (d: unknown, i: number): void => {
-      if (!d) { return; }
+      if (!d) {
+        return;
+      }
       const coordinates = d3.mouse(d3.event.currentTarget);
       const xValue = xScale.invert(coordinates[0]);
       if (xValue > minDuration) {
         startValue = xValue;
         const yValue = getProbabilityForDuration(d as Item[], startValue);
         d3.select(d3.event.currentTarget)
-          .select('.area-clip-rect')
-          .attr('width', xScale(startValue));
+            .select('.area-clip-rect')
+            .attr('width', xScale(startValue));
         d3.select(d3.event.currentTarget)
-          .select('.click-line-y')
-          .attr('y1', yScale(yValue))
-          .attr('x1', xScale(startValue))
-          .attr('x2', xScale(startValue))
-          .attr('opacity', 1);
+            .select('.click-line-y')
+            .attr('y1', yScale(yValue))
+            .attr('x1', xScale(startValue))
+            .attr('x2', xScale(startValue))
+            .attr('opacity', 1);
         d3.select(d3.event.currentTarget)
-          .select('.click-line-x')
-          .attr('y1', yScale(yValue))
-          .attr('y2', yScale(yValue))
-          .attr('x2', xScale(startValue))
-          .attr('opacity', 1);
+            .select('.click-line-x')
+            .attr('y1', yScale(yValue))
+            .attr('y2', yScale(yValue))
+            .attr('x2', xScale(startValue))
+            .attr('opacity', 1);
         d3.select(d3.event.currentTarget)
-          .select('.click-line-y-text')
-          .attr('x', xScale(startValue) - 40)
-          .attr('y', yScale(yValue) + 20)
-          .text(`${this.data.filter(c => c.duration <= startValue).length}/${this.data.length}`)
-          .attr('opacity', 1);
+            .select('.click-line-y-text')
+            .attr('x', xScale(startValue) - 40)
+            .attr('y', yScale(yValue) + 20)
+            .text(`${this.data.filter(c => c.duration <= startValue).length}/${
+                this.data.length}`)
+            .attr('opacity', 1);
         d3.select(d3.event.currentTarget)
-          .select('.click-line-x-text')
-          .attr('x', xScale(startValue) / 2)
-          .attr('y', yScale(yValue) + 10)
-          .text(`${(getProbabilityForDuration(this.data, startValue) * 100).toFixed(1)}%`)
-          .attr('opacity', 1);
+            .select('.click-line-x-text')
+            .attr('x', xScale(startValue) / 2)
+            .attr('y', yScale(yValue) + 10)
+            .text(`${
+                (getProbabilityForDuration(this.data, startValue) * 100)
+                    .toFixed(1)}%`)
+            .attr('opacity', 1);
         d3.select(d3.event.currentTarget)
-          .selectAll('.dots')
-          .data(this.data)
-          .enter()
-          .attr('fill', (d: Item) => (d.duration <= startValue ? 'grey' : 'black'));
+            .selectAll('.dots')
+            .data(this.data)
+            .enter()
+            .attr(
+                'fill',
+                (dp: Item) => (dp.duration <= startValue ? 'grey' : 'black'));
       }
     });
 
@@ -360,73 +372,73 @@ export class CDFComponent implements AfterViewInit {
     const labelFontSize = labelsize[1] / 2;
 
     cdfChart.append('rect')
-      .attr('class', 'x-label-bg')
-      .attr('x', 0)
-      .attr('y', height)
-      .attr('height', labelsize[1])
-      .attr('width', labelsize[0])
-      .attr('fill', highlightColor)
-      .attr('opacity', 0);
+        .attr('class', 'x-label-bg')
+        .attr('x', 0)
+        .attr('y', height)
+        .attr('height', labelsize[1])
+        .attr('width', labelsize[0])
+        .attr('fill', highlightColor)
+        .attr('opacity', 0);
 
     cdfChart.append('text')
-      .attr('text-anchor', 'middle')
-      .attr('class', 'x-label')
-      .attr('x', 0)
-      .attr('y', height + 5 + labelFontSize)
-      .attr('opacity', 0)
-      .style('font-size', `${labelFontSize}px`)
-      .style('font-weight', 'bold')
-      .attr('fill', 'black');
+        .attr('text-anchor', 'middle')
+        .attr('class', 'x-label')
+        .attr('x', 0)
+        .attr('y', height + 5 + labelFontSize)
+        .attr('opacity', 0)
+        .style('font-size', `${labelFontSize}px`)
+        .style('font-weight', 'bold')
+        .attr('fill', 'black');
 
     cdfChart.append('rect')
-      .attr('class', 'y-label-bg')
-      .attr('x', -labelsize[0])
-      .attr('y', 0)
-      .attr('height', labelsize[1])
-      .attr('width', labelsize[0])
-      .attr('fill', highlightColor)
-      .attr('opacity', 0);
+        .attr('class', 'y-label-bg')
+        .attr('x', -labelsize[0])
+        .attr('y', 0)
+        .attr('height', labelsize[1])
+        .attr('width', labelsize[0])
+        .attr('fill', highlightColor)
+        .attr('opacity', 0);
 
     cdfChart.append('text')
-      .attr('text-anchor', 'middle')
-      .attr('class', 'y-label')
-      .attr('x', -labelsize[0] / 2)
-      .attr('y', 0)
-      .attr('opacity', 0)
-      .attr('fill', 'black')
-      .style('font-size', `${labelFontSize}px`);
+        .attr('text-anchor', 'middle')
+        .attr('class', 'y-label')
+        .attr('x', -labelsize[0] / 2)
+        .attr('y', 0)
+        .attr('opacity', 0)
+        .attr('fill', 'black')
+        .style('font-size', `${labelFontSize}px`);
 
     cdfChart.append('line')
-      .attr('x1', 0)
-      .attr('x2', 0)
-      .attr('y1', height)
-      .attr('y2', 0)
-      .attr('class', 'v-ruler')
-      .attr('stroke', 'grey')
-      .attr('stroke-width', 2)
-      .attr('stroke-dasharray', '5,2')
-      .attr('opacity', 0);
+        .attr('x1', 0)
+        .attr('x2', 0)
+        .attr('y1', height)
+        .attr('y2', 0)
+        .attr('class', 'v-ruler')
+        .attr('stroke', 'grey')
+        .attr('stroke-width', 2)
+        .attr('stroke-dasharray', '5,2')
+        .attr('opacity', 0);
 
     cdfChart.append('line')
-      .attr('x1', 0)
-      .attr('x2', width)
-      .attr('y1', 0)
-      .attr('y2', 0)
-      .attr('class', 'h-ruler')
-      .attr('stroke', 'grey')
-      .attr('stroke-width', 2)
-      .attr('stroke-dasharray', '5,2')
-      .attr('opacity', 0);
+        .attr('x1', 0)
+        .attr('x2', width)
+        .attr('y1', 0)
+        .attr('y2', 0)
+        .attr('class', 'h-ruler')
+        .attr('stroke', 'grey')
+        .attr('stroke-width', 2)
+        .attr('stroke-dasharray', '5,2')
+        .attr('opacity', 0);
 
     cdfChart.append('circle')
-      .attr('class', 'marker')
-      .attr('cx', 0)
-      .attr('cy', 0)
-      .attr('r', 5)
-      .attr('stroke', strokeColor)
-      .attr('stroke-width', 2)
-      .attr('fill', circleColor)
-      .style('opacity', 0);
+        .attr('class', 'marker')
+        .attr('cx', 0)
+        .attr('cy', 0)
+        .attr('r', 5)
+        .attr('stroke', strokeColor)
+        .attr('stroke-width', 2)
+        .attr('fill', circleColor)
+        .style('opacity', 0);
 
     cdfChart.on('mouseover', (d: unknown, i: number): void => {
       const mouseX = xScale.invert(d3.mouse(d3.event.currentTarget)[0]);
@@ -441,14 +453,15 @@ export class CDFComponent implements AfterViewInit {
 
       if (checkX) {
         const xVal = d3.mouse(d3.event.currentTarget)[0];
-        const yVal = yScale(getProbabilityForDuration(d as Item[], xScale.invert(xVal)));
+        const xInverted = xScale.invert(xVal);
+        const yVal = yScale(getProbabilityForDuration(d as Item[], xInverted));
 
         marker.attr('cx', xVal).attr('cy', yVal);
         hruler.attr('y1', yVal).attr('y2', yVal);
         vruler.attr('x1', xVal).attr('x2', xVal);
 
-        const xText = d3.format(',.1f')(xScale.invert(+marker.attr('cx')));
-        const yText = d3.format(',.1%')(yScale.invert(+marker.attr('cy')));
+        const xText = d3.format(',.1f')(xInverted);
+        const yText = d3.format(',.1%')(yScale.invert(yVal));
         xlabel.attr('x', +marker.attr('cx')).text(xText);
         xlabelbg.attr('x', +marker.attr('cx') - labelsize[0] / 2);
         ylabel.attr('y', +marker.attr('cy') + labelsize[1] / 5).text(yText);

--- a/web/src/app/components/cdf/cdf.utils.ts
+++ b/web/src/app/components/cdf/cdf.utils.ts
@@ -95,7 +95,7 @@ export function getProbabilityForDuration(
     data: Item[], duration: number): number {
   const allDurations = data.map(d => d.duration);
   const index = d3.bisectLeft(allDurations, duration);
-  if (index == 0) {
+  if (index === 0) {
     return 0;
   }
   return data[index - 1].probability;

--- a/web/src/app/components/cdf/cdf.utils.ts
+++ b/web/src/app/components/cdf/cdf.utils.ts
@@ -95,6 +95,9 @@ export function getProbabilityForDuration(
     data: Item[], duration: number): number {
   const allDurations = data.map(d => d.duration);
   const index = d3.bisectLeft(allDurations, duration);
+  if (index == 0) {
+    return 0;
+  }
   return data[index - 1].probability;
 }
 


### PR DESCRIPTION
This PR adds event handling for mouse clicks and mouse hovers. When a click
occurs on the graph, the area to the left of the clicked value will be shaded lighter,
the dots will change to grey and lines will appear to signify the probability and the
number of points below that value. When the mouse hovers over the graph, two
rulers will appear to show the duration and probability value that the point 
corresponds to.