### PR TITLE
Add a loading indicator for the all-pushes page

### DIFF
--- a/web/src/app/pages/all-pushes/all-pushes.component.html
+++ b/web/src/app/pages/all-pushes/all-pushes.component.html
@@ -5,34 +5,42 @@
     <app-button link='/{{ pushDefName | async }}'>{{ pushDefName | async }}</app-button>
 </app-button-row>
 
-<app-timeline *ngIf='pushInfos | async' [pushInfos]='pushInfos | async'></app-timeline>
+<ng-container *ngIf='pushInfos | async as pushInfos; else loading'>
+    <app-timeline *ngIf='pushInfos' [pushInfos]='pushInfos'></app-timeline>
 
-<table class='collapse bb bw1 b--black' *ngIf='pushInfos | async as pushInfos'>
-    <thead>
-        <tr class='bb bw1 b--black'>
-            <th class='tl br'>Push handle</th>
-            <th class='br'>Last change</th>
-            <th># states</th>
+    <table class='collapse bb bw1 b--black'>
+        <thead>
+            <tr class='bb bw1 b--black'>
+                <th class='tl br'>Push handle</th>
+                <th class='br'>Last change</th>
+                <th># states</th>
+            </tr>
+        </thead>
+        <tr class='hover-bg-light-gray hover-cursor-default'
+            *ngFor='let i of pushInfos; first as isFirst; last as isLast'>
+            <td class='br ph1'
+                [class.pt2]='isFirst'
+                [class.pb2]='isLast'>
+                <a routerLink='/{{ i.pushHandle }}'>{{ i.pushHandle }}</a>
+            </td>
+            <td class='br ph1'
+                [class.pt2]='isFirst'
+                [class.pb2]='isLast'>
+                {{ i.lastChangeNsec | dateNsec }}
+            </td>
+            <td class='tr ph1'
+                [class.pt2]='isFirst'
+                [class.pb2]='isLast'>
+                <ng-container *ngIf='i.stateInfo'>
+                    {{ i.stateInfo.length }}
+                </ng-container>
+            </td>
         </tr>
-    </thead>
-    <tr class='hover-bg-light-gray hover-cursor-default'
-        *ngFor='let i of pushInfos; first as isFirst; last as isLast'>
-        <td class='br ph1'
-            [class.pt2]='isFirst'
-            [class.pb2]='isLast'>
-            <a routerLink='/{{ i.pushHandle }}'>{{ i.pushHandle }}</a>
-        </td>
-        <td class='br ph1'
-            [class.pt2]='isFirst'
-            [class.pb2]='isLast'>
-            {{ i.lastChangeNsec | dateNsec }}
-        </td>
-        <td class='tr ph1'
-            [class.pt2]='isFirst'
-            [class.pb2]='isLast'>
-            <ng-container *ngIf='i.stateInfo'>
-                {{ i.stateInfo.length }}
-            </ng-container>
-        </td>
-    </tr>
-</table>
+    </table>
+</ng-container>
+
+<ng-template #loading>
+    <div>
+        Loading...
+    </div>
+</ng-template>


### PR DESCRIPTION
The loading of the all-pushes page can take quite some time. To improve
the experience this PR adds a 'Loading...' notices to let the user know
that the loading is still in progress.