### PR TITLE
Add two functions for handling push durations

### DIFF
--- a/web/src/app/components/cdf/cdf.component.ts
+++ b/web/src/app/components/cdf/cdf.component.ts
@@ -2,6 +2,7 @@ import {AfterViewInit, Component, ElementRef, Input, ViewChild} from '@angular/c
 import * as d3 from 'd3';
 
 import {step189_2020} from '../../../proto/step189_2020';
+import {findDurationUnit} from '../duration.utils';
 
 import {addCurrentPushLine, generateQuantiles, generateYPosition, populateData} from './cdf.utils';
 import {COMPLETED_BLUE, d3SVG, Item, STROKE_COLOR} from './cdf.utils';
@@ -19,6 +20,8 @@ export class CDFComponent implements AfterViewInit {
 
   private data: Item[] = [];
   private svg: d3SVG|undefined;
+  private durationUnit = '';
+
 
   /**
    * Creates a CDF chart by plotting the duration of completed pushes against
@@ -61,6 +64,7 @@ export class CDFComponent implements AfterViewInit {
     if (!this.currentPush) {
       return;
     }
+    this.durationUnit = findDurationUnit(this.pushInfos);
     this.data = populateData(this.pushInfos);
 
     const element = this.CDFContainer.nativeElement;
@@ -144,7 +148,7 @@ export class CDFComponent implements AfterViewInit {
             `translate(${width / 2}, ${elementHeight - margin.left / 4})`)
         .style('text-anchor', 'middle')
         .style('font-size', '12px')
-        .text('Duration (minutes)');
+        .text(`Duration (${this.durationUnit})`);
 
     this.svg.append('text')
         .attr('id', 'graph-title')

--- a/web/src/app/components/cdf/cdf.component.ts
+++ b/web/src/app/components/cdf/cdf.component.ts
@@ -94,8 +94,11 @@ export class CDFComponent implements AfterViewInit {
     const yScale = d3.scaleLinear().domain([0, 1]).rangeRound([height, 0]);
 
     const extendedData = Array.from(this.data);
-    extendedData.push(
-        {duration: xScale.ticks()[xScale.ticks().length - 1], probability: 1});
+    extendedData.push({
+      duration: xScale.ticks()[xScale.ticks().length - 1],
+      probability: 1,
+      endState: 5
+    });
 
     this.svg = (d3.select(element).append('svg') as d3SVG)
                    .attr('width', elementWidth)

--- a/web/src/app/components/cdf/cdf.component.ts
+++ b/web/src/app/components/cdf/cdf.component.ts
@@ -22,7 +22,6 @@ export class CDFComponent implements AfterViewInit {
   private svg: d3SVG|undefined;
   private durationUnit = '';
 
-
   /**
    * Creates a CDF chart by plotting the duration of completed pushes against
    * the probability of a push taking less time than that duration. Adds lines

--- a/web/src/app/components/cdf/cdf.utils.ts
+++ b/web/src/app/components/cdf/cdf.utils.ts
@@ -3,10 +3,8 @@ import * as d3 from 'd3';
 import {step189_2020} from '../../../proto/step189_2020';
 import {DurationItem, findDurationUnit, findStartandEnd, UNIT_CONVERSION} from '../duration.utils';
 
-
 export interface Item {
-  duration: number;     // Time (in best unit) between last stage and first
-                        // non-empty stage
+  duration: number;     // Time between last stage and first non-empty stage
   probability: number;  // Rank of the duration divided by number of points
   endState: number;     // Tag of the last state
 }
@@ -29,10 +27,11 @@ export const COMPLETED_BLUE = '#00bfa5';
 export const STROKE_COLOR = '#167364';
 
 /**
- * Calculates the duration between the completed stage and the first non-empty
- * stage. Assigns the probability as the rank of the duration value over the
- * total number of points. The duration and probability are defined in an
- * interface and all points stored as an array of CdfData interfaces.
+ * Calculates the duration (in the best unit) between the completed stage and
+ * the first non-empty stage. Assigns the probability as the rank of the
+ * duration value over the total number of points. The duration and probability
+ * are defined in an interface and all points stored as an array of Item
+ * interfaces.
  *
  * @param pushInfos Array of pushes for a single push def
  * @return Array of Items sorted by increasing duration

--- a/web/src/app/components/cdf/cdf.utils.ts
+++ b/web/src/app/components/cdf/cdf.utils.ts
@@ -1,10 +1,12 @@
 import * as d3 from 'd3';
 
 import {step189_2020} from '../../../proto/step189_2020';
+import {DurationItem, findDurationUnit, findStartandEnd, UNIT_CONVERSION} from '../duration.utils';
+
 
 export interface Item {
-  duration:
-      number;  // Minutes between completed stage and first non-empty stage
+  duration: number;     // Time (in best unit) between completed stage and first
+                        // non-empty stage
   probability: number;  // Rank of the duration divided by number of points
 }
 
@@ -35,6 +37,8 @@ export const STROKE_COLOR = '#167364';
  * @return Array of Items sorted by increasing duration
  */
 export function populateData(pushInfos: step189_2020.IPushInfo[]): Item[] {
+  const bestUnit = findDurationUnit(pushInfos);
+  const divisor = UNIT_CONVERSION[findDurationUnit(pushInfos)];
   const durations: number[] = [];
   pushInfos.forEach(pushInfo => {
     if (!pushInfo) {
@@ -53,17 +57,10 @@ export function populateData(pushInfos: step189_2020.IPushInfo[]): Item[] {
       return;
     }
 
-    if (finalState === COMPLETED_STATE_TAG) {
-      // Find the start time of the first non-empty stage.
-      let firstStateStart: number|Long = -1;
-      for (const state of states) {
-        if (state.stage && state.startTimeNsec) {
-          firstStateStart = state.startTimeNsec;
-          break;
-        }
-      }
-      if (firstStateStart !== -1) {
-        const duration = (+pushEndTime - +firstStateStart) / NANO_TO_MINUTES;
+    if (finalState === 5) {
+      const startEnd: DurationItem|undefined = findStartandEnd(pushInfo);
+      if (startEnd) {
+        const duration = (+startEnd.end - +startEnd.start) / divisor;
         durations.push(duration);
       }
     }

--- a/web/src/app/components/cdf/cdf.utils.ts
+++ b/web/src/app/components/cdf/cdf.utils.ts
@@ -1,7 +1,7 @@
 import * as d3 from 'd3';
 
 import {step189_2020} from '../../../proto/step189_2020';
-import {DurationItem, findDurationUnit, findStartandEnd, UNIT_CONVERSION} from '../duration.utils';
+import {DurationItem, findDurationUnit, findDuration, UNIT_CONVERSION} from '../duration.utils';
 
 export interface Item {
   duration: number;     // Time between last stage and first non-empty stage
@@ -56,10 +56,10 @@ export function populateData(pushInfos: step189_2020.IPushInfo[]): Item[] {
       return;
     }
 
-    const startEnd: DurationItem|undefined = findStartandEnd(pushInfo);
+    const startEnd: DurationItem|undefined = findDuration(pushInfo);
     if (startEnd) {
       pushes.push({
-        duration: (+startEnd.end - +startEnd.start) / divisor,
+        duration: (+startEnd.endNsec - +startEnd.startNsec) / divisor,
         probability: 0,
         endState: finalState
       } as Item);

--- a/web/src/app/components/duration.utils.ts
+++ b/web/src/app/components/duration.utils.ts
@@ -1,8 +1,8 @@
 import {step189_2020} from '../../proto/step189_2020';
 
 export interface DurationItem {
-  start: number|Long;  // nsec time of the first non-empty state
-  end: number|Long;    // nsec time of the last state
+  startNsec: number|Long;  // nsec time of the first non-empty state
+  endNsec: number|Long;    // nsec time of the last state
 }
 
 const NANO_TO_DAYS = (10 ** 9) * 60 * 60 * 24;
@@ -20,6 +20,7 @@ export const UNIT_CONVERSION: {[unit: string]: number} = {
 /**
  * Finds the unit of time that best describes the majority of the durations of
  * the pushInfos.
+ *
  * @param pushInfos Array of pushes for a single push def
  * @return one of [seconds, minutes, hours, days]
  */
@@ -46,9 +47,9 @@ export function findDurationUnit(pushInfos: step189_2020.IPushInfo[]): string {
     }
     if (finalState === 5) {
       // Find the start time of the first non-empty stage.
-      const startEnd: DurationItem|undefined = findStartandEnd(pushInfo);
+      const startEnd: DurationItem|undefined = findDuration(pushInfo);
       if (startEnd) {
-        const nsecDuration = (+pushEndTime - +startEnd.start);
+        const nsecDuration = (+pushEndTime - +startEnd.startNsec);
         for (const unit of ['days', 'hours', 'minutes', 'seconds']) {
           if ((nsecDuration / UNIT_CONVERSION[unit]) > 1) {
             unitCounter[unit] += 1;
@@ -70,13 +71,15 @@ export function findDurationUnit(pushInfos: step189_2020.IPushInfo[]): string {
 }
 
 /**
- * Finds the start time of the first non-empty state and the ned time of the
+ * Finds the start time of the first non-empty state and the end time of the
  * pushInfo.
- * @param pushInfo Array of pushes for a single push def
+ *
+ * @param pushInfo A single push
  * @return a DurationItem that has a start of the time of the first non-empty
- *     stage and an end of the time of the last state
+ *     stage and an end of the time of the last state. If there is no state with
+ *     a stage, then return undefined.
  */
-export function findStartandEnd(pushInfo: step189_2020.IPushInfo): DurationItem|
+export function findDuration(pushInfo: step189_2020.IPushInfo): DurationItem|
     undefined {
   const states = pushInfo.stateInfo;
   if (!states) {
@@ -96,5 +99,5 @@ export function findStartandEnd(pushInfo: step189_2020.IPushInfo): DurationItem|
   if (!endTime) {
     return;
   }
-  return {start: firstStateStart, end: endTime} as DurationItem;
+  return {startNsec: firstStateStart, endNsec: endTime} as DurationItem;
 }

--- a/web/src/app/components/duration.utils.ts
+++ b/web/src/app/components/duration.utils.ts
@@ -1,0 +1,99 @@
+import {step189_2020} from '../../proto/step189_2020';
+
+export interface DurationItem {
+  start: number|Long;  // nsec time of the first non-empty state
+  end: number|Long;    // nsec time of the last state
+}
+
+const NANO_TO_DAYS = (10 ** 9) * 60 * 60 * 24;
+const NANO_TO_HOURS: number = (10 ** 9) * 60 * 60;
+const NANO_TO_MINUTES: number = (10 ** 9) * 60;
+const NANO_TO_SECONDS: number = (10 ** 9);
+
+export const UNIT_CONVERSION: {[unit: string]: number} = {
+  seconds: NANO_TO_SECONDS,
+  minutes: NANO_TO_MINUTES,
+  hours: NANO_TO_HOURS,
+  days: NANO_TO_DAYS
+};
+
+/**
+ * Finds the unit of time that best describes the majority of the durations of
+ * the pushInfos.
+ * @param pushInfos Array of pushes for a single push def
+ * @return one of [seconds, minutes, hours, days]
+ */
+export function findDurationUnit(pushInfos: step189_2020.IPushInfo[]): string {
+  const unitCounter:
+      {[unit: string]:
+           number} = {seconds: 0, minutes: 0, hours: 0, days: 0, years: 0};
+
+  pushInfos.forEach(pushInfo => {
+    if (!pushInfo) {
+      return;
+    }
+    const states = pushInfo.stateInfo;
+    if (!states) {
+      return;
+    }
+    const pushEndTime = states[states.length - 1].startTimeNsec;
+    if (!pushEndTime) {
+      return;
+    }
+    const finalState = states[states.length - 1].state;
+    if (!finalState) {
+      return;
+    }
+    if (finalState === 5) {
+      // Find the start time of the first non-empty stage.
+      const startEnd: DurationItem|undefined = findStartandEnd(pushInfo);
+      if (startEnd) {
+        const nsecDuration = (+pushEndTime - +startEnd.start);
+        for (const unit of ['days', 'hours', 'minutes', 'seconds']) {
+          if ((nsecDuration / UNIT_CONVERSION[unit]) > 1) {
+            unitCounter[unit] += 1;
+            break;
+          }
+        }
+      }
+    }
+  });
+  let bestUnit = '';
+  let max = 0;
+  for (const [key, value] of Object.entries(unitCounter)) {
+    if (value > max) {
+      max = value;
+      bestUnit = key;
+    }
+  }
+  return bestUnit;
+}
+/**
+ * Finds the start time of the first non-empty state and the ned time of the
+ * pushInfo.
+ * @param pushInfo Array of pushes for a single push def
+ * @return a DurationItem that has a start of the time of the first non-empty
+ *     stage and an end of the time of the last state
+ */
+export function findStartandEnd(pushInfo: step189_2020.IPushInfo): DurationItem|
+    undefined {
+  const states = pushInfo.stateInfo;
+  if (!states) {
+    return;
+  }
+  let firstStateStart: number|Long = -1;
+  for (const state of states) {
+    if (state.stage && state.startTimeNsec) {
+      firstStateStart = state.startTimeNsec;
+      break;
+    }
+  }
+  if (firstStateStart === -1) {
+    return;
+  }
+  const endTime = states[states.length - 1].startTimeNsec;
+  if (!endTime) {
+    return;
+  }
+  return {start: firstStateStart, end: endTime} as DurationItem;
+}

--- a/web/src/app/components/duration.utils.ts
+++ b/web/src/app/components/duration.utils.ts
@@ -68,6 +68,7 @@ export function findDurationUnit(pushInfos: step189_2020.IPushInfo[]): string {
   }
   return bestUnit;
 }
+
 /**
  * Finds the start time of the first non-empty state and the ned time of the
  * pushInfo.

--- a/web/src/app/components/duration.utils.ts
+++ b/web/src/app/components/duration.utils.ts
@@ -25,40 +25,46 @@ export const UNIT_CONVERSION: {[unit: string]: number} = {
  * @return one of [seconds, minutes, hours, days]
  */
 export function findDurationUnit(pushInfos: step189_2020.IPushInfo[]): string {
-  const unitCounter:
-      {[unit: string]:
-           number} = {seconds: 0, minutes: 0, hours: 0, days: 0, years: 0};
+  const unitCounter: {[unit: string]: number} = {
+    seconds: 0,
+    minutes: 0,
+    hours: 0,
+    days: 0
+  };
 
   pushInfos.forEach(pushInfo => {
     if (!pushInfo) {
       return;
     }
+
     const states = pushInfo.stateInfo;
     if (!states) {
       return;
     }
+
     const pushEndTime = states[states.length - 1].startTimeNsec;
     if (!pushEndTime) {
       return;
     }
+
     const finalState = states[states.length - 1].state;
     if (!finalState) {
       return;
     }
-    if (finalState === 5) {
-      // Find the start time of the first non-empty stage.
-      const startEnd: DurationItem|undefined = findDuration(pushInfo);
-      if (startEnd) {
-        const nsecDuration = (+pushEndTime - +startEnd.startNsec);
-        for (const unit of ['days', 'hours', 'minutes', 'seconds']) {
-          if ((nsecDuration / UNIT_CONVERSION[unit]) > 1) {
-            unitCounter[unit] += 1;
-            break;
-          }
+
+    // Find the start time of the first non-empty stage.
+    const startEnd: DurationItem|undefined = findDuration(pushInfo);
+    if (startEnd) {
+      const nsecDuration = (+pushEndTime - +startEnd.startNsec);
+      for (const unit of ['days', 'hours', 'minutes', 'seconds']) {
+        if ((nsecDuration / UNIT_CONVERSION[unit]) > 1) {
+          unitCounter[unit] += 1;
+          break;
         }
       }
     }
   });
+
   let bestUnit = '';
   let max = 0;
   for (const [key, value] of Object.entries(unitCounter)) {
@@ -85,6 +91,7 @@ export function findDuration(pushInfo: step189_2020.IPushInfo): DurationItem|
   if (!states) {
     return;
   }
+
   let firstStateStart: number|Long = -1;
   for (const state of states) {
     if (state.stage && state.startTimeNsec) {
@@ -92,12 +99,15 @@ export function findDuration(pushInfo: step189_2020.IPushInfo): DurationItem|
       break;
     }
   }
+
   if (firstStateStart === -1) {
     return;
   }
+
   const endTime = states[states.length - 1].startTimeNsec;
   if (!endTime) {
     return;
   }
+
   return {startNsec: firstStateStart, endNsec: endTime} as DurationItem;
 }


### PR DESCRIPTION
This PR adds a function to find the best duration unit for the duration of the 
pushes in a push def as well as a function to find the first non-empty state 
start time. The best duration unit is the maximum time unit that the majority 
of the durations can use. The function to find the first non-empty state start 
time finds the start and end time for that push such that that the start time is 
the start time of the first non-empty state and the end time is the start time of
the last state.